### PR TITLE
Build and instruction fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libtorrent"]
+	path = libtorrent
+	url = https://github.com/arvidn/libtorrent/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You need to first [install homebrew](https://brew.sh) and python-pip (`sudo easy
 Then in a terminal :
 ```
 brew update
-sudo brew install autoconf automake libtool openssl boost boost-python
+brew install autoconf automake libtool openssl boost boost-python
 sudo -H pip2 install gevent msgpack-python
 xcode-select --install
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An attempt to create a plugin that will allow the use of libtorrent to share big
 
 Example site : http://127.0.0.1:43110/1ChMNjXpW5vU5iXb9DSXzqAUfY46Pc2RTL/
 
-## Install
+## Download
 
 In your Zeronet folder :
 ```
@@ -12,18 +12,65 @@ cd plugins
 git clone https://github.com/rllola/zeronet-torrent-plugin.git Torrent --recursive
 ```
 
-### Libtorrent binding config
+### Libtorrent dependencies
 
-Be sure to have this installed for linux (debian/ubuntu) :
+Debian/Ubuntu Linux :
 ```
-apt install autoconf automake libtool libboost-all-dev libssl-dev
+sudo apt install autoconf automake libtool libboost-all-dev libssl-dev
 ```
 
-Configure and build :
+MacOS :
+
+You need to first [install homebrew](https://brew.sh) and python-pip (`sudo easy_install pip`) if you haven't already. 
+Then in a terminal :
+```
+brew update
+sudo brew install autoconf automake libtool openssl boost boost-python
+sudo -H pip2 install gevent msgpack-python
+xcode-select --install
+```
+
+## Building
+
+Linux :
 ```
 cd libtorrent
 ./bootstrap.sh
 make -j$(nproc)
 ```
 
+MacOS :
+```
+cd libtorrent
+./bootstrap.sh --with-openssl=/usr/local/opt/openssl --enable-python-binding
+make -j$(sysctl -n hw.ncpu)
+```
+
+## Installing
+
+Linux :
+```
+sudo make install
+```
+
+MacOS :
+```
+sudo make install
+sudo ./setup.py install
+```
+
 Test here : http://127.0.0.1:43110/1ChMNjXpW5vU5iXb9DSXzqAUfY46Pc2RTL/
+
+## Troubleshooting
+
+### ZeroBundle
+
+This plugin does not work with the default setup in ZeroBundle (currently) as ZeroBundle packages its own python binary (which won't have access to libtorrent).
+
+To work around this, instead of double-clicking the ZeroNet icon, navigate to `WhereverYouDownloadedZeroNet/ZeroNet.app/Contents/Resources/core`, and launch ZeroNet from there with:
+
+```
+python ./zeronet.py
+```
+
+The test page should now no longer report that the plugin is not installed.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,29 @@
 # Torrent Plugin
 
-Attempt to create a plugin that will allow to use libtorrent to share big file !
+An attempt to create a plugin that will allow the use of libtorrent to share big files !
 
 Example site : http://127.0.0.1:43110/1ChMNjXpW5vU5iXb9DSXzqAUfY46Pc2RTL/
 
 ## Install
 
-In you Zeronet folder :
+In your Zeronet folder :
 ```
 cd plugins
-git clone git@github.com:rllola/zeronet-torrent-plugin.git Torrent
+git clone https://github.com/rllola/zeronet-torrent-plugin.git Torrent --recursive
 ```
 
 ### Libtorrent binding config
 
-Be sure to have this install for linux :
+Be sure to have this installed for linux (debian/ubuntu) :
 ```
-apt install autoconf automake libtool libboost-all-dev
+apt install autoconf automake libtool libboost-all-dev libssl-dev
 ```
 
-Configure :
+Configure and build :
 ```
+cd libtorrent
 ./bootstrap.sh
-```
-
-Build libtorrent :
-```
-make
+make -j$(nproc)
 ```
 
 Test here : http://127.0.0.1:43110/1ChMNjXpW5vU5iXb9DSXzqAUfY46Pc2RTL/


### PR DESCRIPTION
Hello there, noticed a couple things off with the repo and fixed them up. This includes:

* Correctly have libtorrent as a [git submodule](https://github.com/blog/2104-working-with-submodules)
* Change clone to use HTTPS instead (got a permission denied error using git@...:rllola) and to use `--recursive` (so the submodules are downloaded)
* Change build instructions to use all available cores (faster building times)
* Some small grammatical fixes